### PR TITLE
v0.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 [![GitHub issues][typedly-badge-issues]][typedly-issues]
 [![GitHub license][typedly-badge-license]][typedly-license]
 
-**Version:** v1.0.0
+**Version:** v0.1.0
 
 A **TypeScript** type definitions package for settings.
 

--- a/README.md
+++ b/README.md
@@ -23,12 +23,13 @@ A **TypeScript** type definitions package for settings.
 - [Installation](#installation)
 - [Api](#api)
   - [Interface](#interface)
+    - [`Length`](#length)
     - [`LengthOptions`](#lengthoptions)
     - [`LengthSettings`](#lengthsettings)
     - [`PatternOptions`](#patternoptions)
     - [`PatternSettings`](#patternsettings)
-    - [`Settings`](#settings)
     - [`ValueSettings`](#valuesettings)
+    - [`Settings`](#settings)
   - [Type](#type)
     - [`DisplaySelectedSettings`](#displayselectedsettings)
     - [`SelectableSettings`](#selectablesettings)
@@ -50,13 +51,17 @@ npm install @typedly/settings --save-peer
 
 ```typescript
 import {
-  // Interface
+  // Length.
+  Length,
   LengthOptions,
   LengthSettings,
+  // Pattern.
   PatternOptions,
   PatternSettings,
-  Settings,
+  // Value.
   ValueSettings,
+  // Settings.
+  Settings,
    // Type.
   DisplaySelectedSettings,
   SelectableSettings,
@@ -65,6 +70,19 @@ import {
 
 ### Interface
 
+#### `Length`
+
+[`length-options.interface.ts`](https://github.com/typedly/settings/blob/main/src/interface/length.interface.ts)
+
+```typescript
+import { Length } from '@typedly/settings';
+
+export const length: Length<0, 27, 47> = {
+  'min': 27,
+  'max': 47,
+}
+```
+
 #### `LengthOptions`
 
 [`length-options.interface.ts`](https://github.com/typedly/settings/blob/main/src/interface/length-options.interface.ts)
@@ -72,22 +90,9 @@ import {
 ```typescript
 import { LengthOptions } from '@typedly/settings';
 
-const lengthOptions: LengthOptions<27, 47> = {
+export const length: LengthOptions<0, 27, 47> = {
   'min': 27,
   'max': 47,
-}
-```
-
-#### `PatternOptions`
-
-[`pattern-options.interface.ts`](https://github.com/typedly/settings/blob/main/src/interface/pattern-options.interface.ts)
-
-```typescript
-import { PatternOptions } from '@typedly/settings';
-
-export const patternOptions: PatternOptions = {
-  regexp: /^[a-zA-Z0-9_-]+$/,
-  lowercase: true,
 }
 ```
 
@@ -98,11 +103,32 @@ export const patternOptions: PatternOptions = {
 ```typescript
 import { LengthSettings } from '@typedly/settings';
 
-export const lengthSettings: LengthSettings<27, 47> = {
+export const lengthSettings: LengthSettings<0, 27, 47> = {
   length: {
-    'min': 27,
-    'max': 47,
+    value: 0,
+    min: 27,
+    max: 47,
   }
+}
+
+export const lengthExactSettings: LengthSettings<27> = {
+  length: 27
+}
+```
+
+#### `PatternOptions`
+
+[`pattern-options.interface.ts`](https://github.com/typedly/settings/blob/main/src/interface/pattern-options.interface.ts)
+
+```typescript
+import { PatternOptions } from '@typedly/settings';
+
+const patternOptions: PatternOptions = {
+  lowercase: true,
+  numeric: true,
+  regexp: /^[a-zA-Z0-9_-]+$/,
+  special: true,
+  uppercase: true,
 }
 ```
 
@@ -117,10 +143,26 @@ export const patternSettings: PatternSettings<RegExp> = {
   pattern: {
     lowercase: true,
     numeric: true,
-    regexp: /[a]g/g,
+    regexp: /^[a-zA-Z0-9_-]+$/,
     special: true,
     uppercase: true,
   },
+}
+
+export const patternRegExpSettings: PatternSettings<RegExp> = {
+  pattern: /^[a-zA-Z0-9_-]+$/
+}
+```
+
+#### `ValueSettings`
+
+[`value-settings.interface.ts`](https://github.com/typedly/settings/blob/main/src/interface/value-settings.interface.ts)
+
+```typescript
+import { ValueSettings } from '@typedly/settings';
+
+export const valueSettings: ValueSettings<'the value'> = {
+  value: 'the value'
 }
 ```
 
@@ -133,6 +175,7 @@ import { Settings } from '@typedly/settings';
 
 export const settings: Settings<
   'abcd1234',
+  number,
   27,
   34,
   RegExp
@@ -149,18 +192,6 @@ export const settings: Settings<
   },
   // ValueSettings
   value: 'abcd1234',
-}
-```
-
-#### `ValueSettings`
-
-[`value-settings.interface.ts`](https://github.com/typedly/settings/blob/main/src/interface/value-settings.interface.ts)
-
-```typescript
-import { ValueSettings } from '@typedly/settings';
-
-export const patternSettings: ValueSettings<'the value'> = {
-  value: 'the value'
 }
 ```
 
@@ -184,6 +215,7 @@ import { SelectableSettings } from '@typedly/settings';
 export const settings: SelectableSettings<
   ['length', 'value'],
   'abcd1234',
+  number,
   27,
   34,
   RegExp

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typedly/settings",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "author": "wwwdev.io <dev@wwwdev.io>",
   "description": "A TypeScript type definitions package for settings.",
   "license": "MIT",

--- a/src/interface/index.ts
+++ b/src/interface/index.ts
@@ -1,6 +1,10 @@
+// Length.
+export type { Length } from './length.interface';
 export type { LengthOptions } from './length-options.interface';
 export type { LengthSettings } from './length-settings.interface';
+// Pattern.
 export type { PatternOptions } from './pattern-options.interface';
 export type { PatternSettings } from './pattern-settings.interface';
+// Settings.
 export type { Settings } from './settings.interface';
 export type { ValueSettings } from './value-settings.interface';

--- a/src/interface/length-options.interface.ts
+++ b/src/interface/length-options.interface.ts
@@ -11,7 +11,22 @@ export interface LengthOptions<
   Min extends number = number,
   Max extends number = number
 > {
+  
+  /**
+   * @description Represents expected length of the value, also between min and max.
+   * @type {?Value}
+   */
   value?: Value;
+
+  /**
+   * @description Represents the minimum length of the value.
+   * @type {?Min}
+   */
   min?: Min;
+
+  /**
+   * @description Represents the maximum length of the value.
+   * @type {?Max}
+   */
   max?: Max;
 }

--- a/src/interface/length-options.interface.ts
+++ b/src/interface/length-options.interface.ts
@@ -1,7 +1,17 @@
+/**
+ * @description Represents options for length validation.
+ * @export
+ * @interface Length
+ * @template {number} [Value=number] The expected length of the value, also between min and max.
+ * @template {number} [Min=number] The minimum length of the value.
+ * @template {number} [Max=number] The maximum length of the value.
+ */
 export interface LengthOptions<
+  Value extends number = number,
   Min extends number = number,
   Max extends number = number
 > {
+  value?: Value;
   min?: Min;
   max?: Max;
 }

--- a/src/interface/length-settings.interface.ts
+++ b/src/interface/length-settings.interface.ts
@@ -1,9 +1,19 @@
+// Interface.
 import { LengthOptions } from "./length-options.interface";
-
+/**
+ * @description Represents the settings for a length configuration.
+ * @export
+ * @interface LengthSettings
+ * @template {number} [Value=number] The expected length of the value, also between min and max.
+ * @template {number} [Min=number] The minimum length of the value.
+ * @template {number} [Max=number] The maximum length of the value.
+ * @template {object} [Options=Value<Min, Max>] The options for the length settings as enhanced customization.
+ */
 export interface LengthSettings<
+  Value extends number = number,
   Min extends number = number,
   Max extends number = number,
-  Options extends object = LengthOptions<Min, Max>
+  Options extends object = LengthOptions<Value, Min, Max>
 > {
-  length: Options;
+  length: Value | Options;
 }

--- a/src/interface/length.interface.ts
+++ b/src/interface/length.interface.ts
@@ -1,0 +1,16 @@
+// Interface.
+import { LengthOptions } from "./length-options.interface";
+/**
+ * @description Alias for LengthOptions, representing the settings for a length configuration.
+ * @export
+ * @interface Length
+ * @template {number} [Value=number] The expected length of the value, also between min and max.
+ * @template {number} [Min=number] The minimum length of the value.
+ * @template {number} [Max=number] The maximum length of the value.
+ * @extends {LengthOptions<Value, Min, Max>}
+ */
+export interface Length<
+  Value extends number = number,
+  Min extends number = number,
+  Max extends number = number
+> extends LengthOptions<Value, Min, Max> {}

--- a/src/interface/pattern-options.interface.ts
+++ b/src/interface/pattern-options.interface.ts
@@ -1,9 +1,37 @@
-export interface PatternOptions<
-  Pattern extends RegExp = RegExp,
-> {
-  regexp?: Pattern
+/**
+ * @description Represents the pattern options for validation settings.
+ * @export
+ * @interface Pattern
+ * @template {RegExp} [Pattern=RegExp] The regular expression pattern to match.
+ */
+export interface PatternOptions<Value extends RegExp = RegExp> {
+  /**
+   * @description Represents the regular expression pattern to match.
+   * @type {?Value}
+   */
+  regexp?: Value;
+  
+  /**
+   * @description Represents the lowercase option for the pattern validation.
+   * @type {?boolean}
+   */
   lowercase?: boolean;
+
+  /**
+   * @description Represents the uppercase option for the pattern validation.
+   * @type {?boolean}
+   */
   uppercase?: boolean;
+
+  /**
+   * @description Represents the numeric option for the pattern validation.
+   * @type {?boolean}
+   */
   numeric?: boolean;
+
+  /**
+   * @description Represents the special option for the pattern validation.
+   * @type {?boolean}
+   */
   special?: boolean;
 };

--- a/src/interface/pattern-settings.interface.ts
+++ b/src/interface/pattern-settings.interface.ts
@@ -1,8 +1,15 @@
+// Interface.
 import { PatternOptions } from "./pattern-options.interface";
-
+/**
+ * @description Represents the settings for pattern validation.
+ * @export
+ * @interface PatternSettings
+ * @template {RegExp} [Value=RegExp] The type of the regular expression pattern.
+ * @template {object} [Options=PatternOptions<Value>] The type of the options for the pattern as enhanced customization.
+ */
 export interface PatternSettings<
-  Pattern extends RegExp = RegExp,
-  Options extends object = PatternOptions<Pattern>
+  Value extends RegExp = RegExp,
+  Options extends object = PatternOptions<Value>
 > {
-  pattern: Options
+  pattern: Value | Options
 }

--- a/src/interface/settings.interface.ts
+++ b/src/interface/settings.interface.ts
@@ -1,14 +1,27 @@
+// Interface.
 import { LengthSettings } from "./length-settings.interface";
 import { PatternSettings } from "./pattern-settings.interface";
 import { ValueSettings } from "./value-settings.interface";
-
+/**
+ * @description Represents the settings for a configuration that includes value, length, and pattern validation.
+ * @export
+ * @interface Settings
+ * @template [Value=string] 
+ * @template {number} [Min=number] The type of the minimum length of the value.
+ * @template {number} [Max=number] The type of the maximum length of the value.
+ * @template {RegExp} [Pattern=RegExp] The type of pattern to match against the value.
+ * @extends {ValueSettings<Value>} Extends the ValueSettings interface for value validation.
+ * @extends {LengthSettings<Min, Max>} Extends the LengthSettings interface for length validation.
+ * @extends {PatternSettings<Pattern>} Extends the PatternSettings interface for pattern validation.
+ */
 export interface Settings<
   Value = string,
+  Length extends number = number,
   Min extends number = number,
   Max extends number = number,
   Pattern extends RegExp = RegExp
 > extends
   ValueSettings<Value>,
-  LengthSettings<Min, Max>,
+  LengthSettings<Length, Min, Max>,
   PatternSettings<Pattern> {
 }

--- a/src/interface/value-settings.interface.ts
+++ b/src/interface/value-settings.interface.ts
@@ -1,3 +1,9 @@
+/**
+ * @description Represents the settings for a value configuration.
+ * @export
+ * @interface ValueSettings 
+ * @template Value The type of the value to be validated.
+ */
 export interface ValueSettings<Value> {
   value: Value;
 }

--- a/src/public-api.ts
+++ b/src/public-api.ts
@@ -1,17 +1,21 @@
 /*
  * Public API Surface of settings
  */
-
 export type {
-  Settings,
-  LengthSettings,
+  // Length.
+  Length,
   LengthOptions,
+  LengthSettings,
+  // Pattern.
   PatternOptions,
   PatternSettings,
-  ValueSettings
+  // Value.
+  ValueSettings,
+  // Settings.
+  Settings,
 } from './interface';
 
 export type {
+  DisplaySelectedSettings,
   SelectableSettings,
-  DisplaySelectedSettings
 } from './type';

--- a/src/test/length-options.spec.ts
+++ b/src/test/length-options.spec.ts
@@ -1,6 +1,6 @@
-import { LengthOptions } from '../interface';
+import { Length } from '../interface';
 
-const lengthOptions: LengthOptions<27, 47> = {
+const length: Length<0, 27, 47> = {
   'min': 27,
   'max': 47,
 }

--- a/src/test/length-settings.spec.ts
+++ b/src/test/length-settings.spec.ts
@@ -1,8 +1,13 @@
 import { LengthSettings } from '../interface';
 
-export const lengthSettings: LengthSettings<27, 47> = {
+export const lengthSettings: LengthSettings<0, 27, 47> = {
   length: {
-    'min': 27,
-    'max': 47,
+    value: 0,
+    min: 27,
+    max: 47,
   }
+}
+
+export const lengthExactSettings: LengthSettings<27> = {
+  length: 27
 }

--- a/src/test/pattern-options.spec.ts
+++ b/src/test/pattern-options.spec.ts
@@ -1,8 +1,6 @@
 import { PatternOptions } from '../interface/';
 
-const lengthOptions: PatternOptions<
-  RegExp
-> = {
+const patternOptions: PatternOptions<RegExp> = {
   lowercase: true,
   numeric: true,
   regexp: /[a]g/g,

--- a/src/test/pattern-settings.spec.ts
+++ b/src/test/pattern-settings.spec.ts
@@ -9,3 +9,7 @@ export const patternSettings: PatternSettings<RegExp> = {
     uppercase: true,
   },
 }
+
+export const patternRegExpSettings: PatternSettings<RegExp> = {
+  pattern: /[a]g/g
+}

--- a/src/test/pattern-settings.spec.ts
+++ b/src/test/pattern-settings.spec.ts
@@ -4,12 +4,12 @@ export const patternSettings: PatternSettings<RegExp> = {
   pattern: {
     lowercase: true,
     numeric: true,
-    regexp: /[a]g/g,
+    regexp: /^[a-zA-Z0-9_-]+$/,
     special: true,
     uppercase: true,
   },
 }
 
 export const patternRegExpSettings: PatternSettings<RegExp> = {
-  pattern: /[a]g/g
+  pattern: /^[a-zA-Z0-9_-]+$/
 }

--- a/src/test/selectable-settings.spec.ts
+++ b/src/test/selectable-settings.spec.ts
@@ -3,6 +3,7 @@ import { SelectableSettings } from "../type";
 export const settings: SelectableSettings<
   ['length', 'value'],
   'abcd1234',
+  number,
   27,
   34,
   RegExp

--- a/src/test/settings.spec.ts
+++ b/src/test/settings.spec.ts
@@ -2,6 +2,7 @@ import { Settings } from '../interface';
 
 export const settings: Settings<
   'abcd1234',
+  number,
   27,
   34,
   RegExp

--- a/src/test/value-settings.spec.ts
+++ b/src/test/value-settings.spec.ts
@@ -1,5 +1,5 @@
 import { ValueSettings } from '../interface';
 
-export const patternSettings: ValueSettings<'the value'> = {
+export const valueSettings: ValueSettings<'the value'> = {
   value: 'the value'
 }

--- a/src/type/selectable-settings.type.ts
+++ b/src/type/selectable-settings.type.ts
@@ -1,6 +1,17 @@
+// Interface.
 import { Settings } from '../interface';
+// Type.
 import { DisplaySelectedSettings } from './display-selected-settings.type';
-
+/**
+ * @description Represents the selectable settings for a configuration that includes value, length, and pattern validation.
+ * @export
+ * @template {readonly (keyof Settings)[]} Display Selected settings to be displayed.
+ * @template [Value=string] The type of the value to be validated, defaults to string.
+ * @template {number} [Length=number] The type of the length of the value, defaults to number.
+ * @template {number} [Min=number] The type of the minimum length of the value, defaults to number.
+ * @template {number} [Max=number] The type of the maximum length of the value, defaults to number.
+ * @template {RegExp} [Pattern=RegExp] The type of pattern to match against the value, defaults to RegExp.
+ */
 export type SelectableSettings<
   Display extends readonly (keyof Settings)[],
   Value = string,

--- a/src/type/selectable-settings.type.ts
+++ b/src/type/selectable-settings.type.ts
@@ -4,7 +4,8 @@ import { DisplaySelectedSettings } from './display-selected-settings.type';
 export type SelectableSettings<
   Display extends readonly (keyof Settings)[],
   Value = string,
+  Length extends number = number,
   Min extends number = number,
   Max extends number = number,
   Pattern extends RegExp = RegExp
-> = DisplaySelectedSettings<Display, Settings<Value, Min, Max, Pattern>>;
+> = DisplaySelectedSettings<Display, Settings<Value, Length, Min, Max, Pattern>>;


### PR DESCRIPTION
### v0.1.0

- Handle the exact value in the `LengthSettings` and `PatternSettings`. 040e6c75904a81c143f8dd7aa588b0bb2a5815f3 a2de7cff45c63330591f0f3f2ca692a13115a8b9
- Add `value` in the `LengthOptions` and `LengthSettings`. a1ceffb9dd65acd13559f3b2ae6877bddaa66a4e 
- Add alias `Length` for `LengthOptions`. 22878c41f0df37ee9714f0dd246b7967074361a0
- Add documentation.